### PR TITLE
Bump commons-collections in /Algorithms/2011-SLPA/src_refactor

### DIFF
--- a/Algorithms/2011-SLPA/src_refactor/pom.xml
+++ b/Algorithms/2011-SLPA/src_refactor/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
 
 


### PR DESCRIPTION
Bumps commons-collections from 3.2.1 to 3.2.2.

Signed-off-by: dependabot[bot] <support@github.com>